### PR TITLE
linkjes gefixed

### DIFF
--- a/docs/architectuurprincipes/index.md
+++ b/docs/architectuurprincipes/index.md
@@ -1,7 +1,8 @@
 # Architectuurprincipes
 
-Uit de beleidskaders extraheren we architectuurprincipes die we daarna
-realiseren in [implicaties](../implicaties/).
+Op basis van de beleidskaders zijn een aantal architectuurprincipes opgesteld voor Geonovum.
+
+Uit deze richtinggevende uitspraken volgen ook een aantal consequenties die uitgewerkt zijn onder [implicaties](../implicaties/index.md)
 
 ## AP-01 Open
 

--- a/docs/beleidskaders/index.md
+++ b/docs/beleidskaders/index.md
@@ -9,4 +9,4 @@ bij het bereiken van de doelstellingen van Geonovum. Deze vinden wij in de volge
 - Het [I&A beleidsplan](TODO) van Geonovum.
 
 
-Uit deze beleidskaders abstraheren we [architectuurprincipes](../architectuurprincipes/)
+Uit deze beleidskaders abstraheren we [architectuurprincipes](../architectuurprincipes/index.md)

--- a/docs/implicaties/index.md
+++ b/docs/implicaties/index.md
@@ -6,8 +6,8 @@ BOMOS is hét Beheer- en OntwikkelModel voor Open Standaarden.
 
 Is implicatie van:
 
-- Open
-- Betrouwbaar
+- [Open](../architectuurprincipes/index.md#ap-01-open)
+- [Betrouwbaar](../architectuurprincipes/index.md#ap-05-betrouwbaar)
 
 ## IMP-002: We gebruiken MIM
 
@@ -15,7 +15,7 @@ MIM is een veelgebruikte standaard voor informatiemodellering binnen de overheid
 
 Is implicatie van:
 
-- Standaard
+- [Standaard](../architectuurprincipes/index.md#ap-07-standaard)
 
 ## IMP-003: We gebruiken NEN3610 
 
@@ -23,13 +23,13 @@ NEN 3610  is een veelgebruikte standaard voor geoinformatie binnen Nederland.
 
 Is implicatie van:
 
-- Standaard
+- [Standaard](../architectuurprincipes/index.md#ap-07-standaard)
 
 ## IMP-004 Aansluitend op Landelijke digitale overheid
 
 Is implicatie van:
 
-- Samenwerken
+- [Netwerk](../architectuurprincipes/index.md#ap-02-netwerk)
 
 
 ## IMP-005 Aansluitend op Europese ontwikkelingen
@@ -38,7 +38,7 @@ De architectuur moet  passen in de bewegingen van de digitale overheid op europe
 
 Is implicatie van:
 
-- Samenwerken
+- [Netwerk](../architectuurprincipes/index.md#ap-02-netwerk)
 
 ## IMP-007 Aansluitend op NGII
 
@@ -46,7 +46,7 @@ De architectuur van Geonovum beweegt mee met upgrades van de nationale geodata i
 
 Is implicatie van:
 
-- Samenwerken
+- [Netwerk](../architectuurprincipes/index.md#ap-02-netwerk)
 
 ## IMP-008 Geborgd
 
@@ -58,7 +58,7 @@ We publiceren niet alleen standaarden die specifiek zijn voor  de geo-wereld, ma
 
 Is implicatie van:
 
-- Open
+- [Open](../architectuurprincipes/index.md#ap-01-open)
 
 ## IMP-010 Kwaliteitsborging
 
@@ -98,8 +98,9 @@ Waar mogelijk passen we de Model Driven Approach to waarbij we artifacten met ee
 op de knop afleiden. 
 
 Is implicatie van:
-- Standaard
-- Wendbaar
+
+- [Standaard](../architectuurprincipes/index.md#ap-07-standaard)
+- [Wendbaar](../architectuurprincipes/index.md#ap-04-wendbaar)
 
 
 ## IMP-019 Tooling ondersteunt open standaarden

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,10 @@
 
 **Deze pagina is nog in ontwikkeling**
 
-Welkom bij de architectuurpagina van Geonovum. Uit [beleidskaders](beleidskaders/) (beleidsvisie, beleidsplan, doelstelling, handboeken, BOMOS) komen we tot formulering van [architectuurprincipes](architectuurprincipes/). Deze
-principes werken we verder uit tot [implicaties](implicaties) voor hoe wij onze infrastructuur inregelen.
+Welkom bij de architectuurpagina van Geonovum. Uit [beleidskaders](beleidskaders/index.md) (beleidsvisie, beleidsplan, doelstelling, handboeken, BOMOS) komen we tot formulering van [architectuurprincipes](architectuurprincipes/index.md). Deze
+principes werken we verder uit tot [implicaties](implicaties/index.md) voor hoe wij onze infrastructuur inregelen.
 
-Beslissingen die we nemen met impact op architectuure documenten we in ['Architecure Decision Records' (ADRs)](adr/).
+Beslissingen die we nemen met impact op architectuure documenten we in ['Architecure Decision Records' (ADRs)](adr/index.md).
 
 Onze architectuur beschrijft alle producten van Geonovum. Dit zijn:
 


### PR DESCRIPTION
- ik zag wat waarschuwingen in mkdocs serve langskomen
- je kunt ook 'deeplinks' leggen naar headings in een pagina. zo krijg je links tussen de implicaties en de principes
- ik vind niet dat je implicaties realiseert vanuit je principes. dus ik heb de zin aangepast